### PR TITLE
View Caching

### DIFF
--- a/actions/view.js
+++ b/actions/view.js
@@ -45,7 +45,7 @@ module.exports = function (plugin, options, seneca) {
 						.then(function (related) {
 							// Attach the included entities to the view and cache it without decorated user entitlements
 							view.included$ = related;
-							cache.get(args.id, view);
+							cache.set(args.id, view);
 
 							// If fetchView was supplied a user then decoracte the includes with entitlements
 							if (args.user) {

--- a/actions/view.js
+++ b/actions/view.js
@@ -1,0 +1,64 @@
+'use strict';
+
+var lruCache = require('lru-cache');
+var _ = require('lodash');
+var Promise = require('bluebird');
+var userEntitlements = require('../lib/user-entitlements');
+
+var DataStore = require('../lib/data-store');
+
+module.exports = function (plugin, options, seneca) {
+	var cache = lruCache(options.lruCache);
+	var store = new DataStore();
+	var act = Promise.promisify(seneca.act, seneca);
+	var entity = seneca.make('catalog/view');
+
+	store.init({seneca: seneca, entity: entity});
+
+	seneca.add({role: plugin, cmd: 'fetchView'}, fetchView);
+	seneca.add({role: plugin, cmd: 'fetchViews'}, store.fetchEntities);
+	seneca.add({role: plugin, cmd: 'createView'}, store.createEntity);
+	seneca.add({role: plugin, cmd: 'upsertView'}, store.upsertEntity);
+	seneca.add({role: plugin, cmd: 'deleteView'}, store.deleteEntity);
+
+	function fetchView(args, done) {
+		// Pull the view from cache
+		var view = cache.get(args.id);
+		if (view) {
+			// If fetchView was supplied a user then decoracte the includes with entitlements
+			if (args.user) {
+				view.included$ = _.map(view.included$, function (entity) {
+					return userEntitlements(entity, args.user);
+				});
+			}
+			done(null, view);
+		} else {
+			// If the view was not in the cache, load it from the db
+			entity.load$(args.id, function (err, view) {
+				if (err) {
+					return done(null);
+				}
+
+				if (view) {
+					// Always fetch related for views with at least depth 1
+					act({role: 'catalog', cmd: 'related', entity: view, depth: args.depth || 1})
+						.then(function (related) {
+							// Attach the included entities to the view and cache it without decorated user entitlements
+							view.included$ = related;
+							cache.get(args.id, view);
+
+							// If fetchView was supplied a user then decoracte the includes with entitlements
+							if (args.user) {
+								view.included$ = _.map(view.included$, function (entity) {
+									return userEntitlements(entity, args.user);
+								});
+							}
+							done(null, view);
+						});
+				} else {
+					done(null, null);
+				}
+			});
+		}
+	}
+};

--- a/odd-catalog.js
+++ b/odd-catalog.js
@@ -9,8 +9,8 @@ var deleteByQuery = require('elasticsearch-deletebyquery');
 module.exports = function (options) {
 	var seneca = this;
 	var plugin = 'catalog';
-	var genericEntities = ['promotion', 'query', 'view', 'article', 'event', 'external'];
-	var specialEntities = ['live-stream', 'video', 'collection'];
+	var genericEntities = ['promotion', 'query', 'article', 'event', 'external'];
+	var specialEntities = ['live-stream', 'video', 'collection', 'view'];
 	var senecaEntityMap;
 
 	// ElasticSearch Entities

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oddnetworks/seneca-odd-catalog",
-  "version": "3.0.1",
+  "version": "3.0.3",
   "description": "",
   "main": "odd-catalog.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "node": "4.2.4"
   },
   "dependencies": {
+    "@oddnetworks/odd-schemas": "git+https://git@github.com/oddnetworks/odd-schemas.git",
     "async": "^1.3.0",
     "aws4": "^1.2.1",
     "bluebird": "^2.9.25",
@@ -36,7 +37,7 @@
     "inflection": "^1.7.1",
     "interpolate": "^0.1.0",
     "lodash": "^4.2.1",
-    "@oddnetworks/odd-schemas": "git+https://git@github.com/oddnetworks/odd-schemas.git",
+    "lru-cache": "^4.0.0",
     "parambulator": "^1.5.0",
     "seneca": "^0.6.3",
     "uuid": "^2.0.1"

--- a/test/config.js
+++ b/test/config.js
@@ -5,7 +5,11 @@ module.exports = {
 		add: false
 	},
 	catalog: {
-		enableFlush: true
+		enableFlush: true,
+		lruCache: {
+			max: 50,
+			maxAge: 5 * 60 * 1000
+		}
 	},
 	elasticsearch: {
 		host: '127.0.0.1:9200',

--- a/test/seed/catalog_video/a-video-without-feature-keys.json
+++ b/test/seed/catalog_video/a-video-without-feature-keys.json
@@ -13,5 +13,8 @@
 	},
 	"url": "http://example.com/video.m3u8",
 	"duration": 300,
-	"releaseDate": "2015-04-21T09:01:23.000Z"
+	"releaseDate": "2015-04-21T09:01:23.000Z",
+	"meta": {
+		"entitlements": ["bald", "bearded", "beautiful"]
+	}
 }

--- a/test/view_test.js
+++ b/test/view_test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 // Nuke any existing log files
+var _ = require('lodash');
 var test	 = require('tape');
 var seneca = require('./seneca_helper');
 var pin		= seneca.pin({role: 'catalog', cmd: '*'});
@@ -8,52 +9,73 @@ var async	= require('async');
 
 var before = test;
 
-before('before all tests', function (t) {
-	async.series([
-		seneca.next_act('role:catalog,cmd:seed')
-	], t.end);
-});
-
-test('A view can be fetched', function (t) {
-	t.plan(2);
-
-	pin.fetchView({id: '2a181af0-eea5-4a11-8c5a-3c2d146657d7'}, function (err, out) {
-		t.equal(out.id, '2a181af0-eea5-4a11-8c5a-3c2d146657d7');
-		t.equal(out.included, undefined);
-		t.end(err);
+seneca.ready(function () {
+	before('before all tests', function (t) {
+		async.series([
+			seneca.next_act('role:catalog,cmd:seed')
+		], t.end);
 	});
-});
 
-test('A view can be fetched using utter garbage as an id', function (t) {
-	t.plan(1);
+	test('A view can be fetched', function (t) {
+		t.plan(3);
 
-	pin.fetchView({id: '#$%^&*()'}, function (err, data) {
-		t.equal(data, null);
-		t.end(err);
+		pin.fetchView({id: '2a181af0-eea5-4a11-8c5a-3c2d146657d7'}, function (err, out) {
+			t.equal(out.id, '2a181af0-eea5-4a11-8c5a-3c2d146657d7');
+			t.equal(out.included$.length, 5);
+			t.equal(out.included$[0].meta.entitled, true);
+			t.end(err);
+		});
 	});
-});
 
-test('A view can be listed', function (t) {
-	t.plan(1);
+	test('A view can be fetched with a user', function (t) {
+		t.plan(4);
 
-	pin.fetchViews({}, function (err, out) {
-		t.ok(Array.isArray(out));
-		t.end(err);
+		var user = {
+			userEntitlements: ['wicked-awesome']
+		};
+
+		pin.fetchView({id: '2a181af0-eea5-4a11-8c5a-3c2d146657d7', user: user}, function (err, out) {
+			t.equal(out.id, '2a181af0-eea5-4a11-8c5a-3c2d146657d7');
+			t.equal(out.included$.length, 5);
+
+			var video = _.find(out.included$, {id: 'a-video-without-feature-keys'});
+			t.equal(video.meta.entitled, false);
+			t.equal(out.included$[0].meta.entitled, true);
+			t.end(err);
+		});
 	});
-});
 
-test('A view can be created, then fetched, then deleted', function (t) {
-	t.plan(3);
+	test('A view can be fetched using utter garbage as an id', function (t) {
+		t.plan(1);
 
-	pin.createView({name: 'qux'}, function (newEntityErr, newEntity) {
-		t.equal(newEntity.name, 'qux');
+		pin.fetchView({id: '#$%^&*()'}, function (err, data) {
+			t.equal(data, null);
+			t.end(err);
+		});
+	});
 
-		pin.fetchView({id: newEntity.id}, function (fetchEntityErr, fetchedEntity) {
-			t.equal(fetchedEntity.name, 'qux');
+	test('A view can be listed', function (t) {
+		t.plan(1);
 
-			pin.deleteView({id: fetchedEntity.id}, function (deleteEntityErr) {
-				t.equal(deleteEntityErr, null);
-				t.end(newEntityErr && fetchEntityErr && deleteEntityErr);
+		pin.fetchViews({}, function (err, out) {
+			t.ok(Array.isArray(out));
+			t.end(err);
+		});
+	});
+
+	test('A view can be created, then fetched, then deleted', function (t) {
+		t.plan(3);
+
+		pin.createView({name: 'qux'}, function (newEntityErr, newEntity) {
+			t.equal(newEntity.name, 'qux');
+
+			pin.fetchView({id: newEntity.id}, function (fetchEntityErr, fetchedEntity) {
+				t.equal(fetchedEntity.name, 'qux');
+
+				pin.deleteView({id: fetchedEntity.id}, function (deleteEntityErr) {
+					t.equal(deleteEntityErr, null);
+					t.end(newEntityErr && fetchEntityErr && deleteEntityErr);
+				});
 			});
 		});
 	});

--- a/test/view_test.js
+++ b/test/view_test.js
@@ -21,7 +21,7 @@ seneca.ready(function () {
 
 		pin.fetchView({id: '2a181af0-eea5-4a11-8c5a-3c2d146657d7'}, function (err, out) {
 			t.equal(out.id, '2a181af0-eea5-4a11-8c5a-3c2d146657d7');
-			t.equal(out.included$.length, 5);
+			t.equal(out.included$.length, 6);
 			t.equal(out.included$[0].meta.entitled, true);
 			t.end(err);
 		});
@@ -36,7 +36,7 @@ seneca.ready(function () {
 
 		pin.fetchView({id: '2a181af0-eea5-4a11-8c5a-3c2d146657d7', user: user}, function (err, out) {
 			t.equal(out.id, '2a181af0-eea5-4a11-8c5a-3c2d146657d7');
-			t.equal(out.included$.length, 5);
+			t.equal(out.included$.length, 6);
 
 			var video = _.find(out.included$, {id: 'a-video-without-feature-keys'});
 			t.equal(video.meta.entitled, false);


### PR DESCRIPTION
Adding an LRU cache to fetching views before decorating with specific user entitlements and attache `included$` to make it a single call to cache before sending back to client.

This should not be merged before the other include-scope branch since that logic should be incorporated here.